### PR TITLE
Persistent fragments in NavigationActivity

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -71,13 +71,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -85,27 +78,26 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/build-info" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/split-apk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/splits-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
@@ -115,84 +107,85 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 26 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="com.android.support:animated-vector-drawable-27.0.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-core-utils-27.0.0" level="project" />
+    <orderEntry type="library" name="com.android.support:animated-vector-drawable-27.0.1" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-places-4.29.0" level="project" />
+    <orderEntry type="library" name="com.android.support:support-core-utils-27.0.1" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-share-4.29.0" level="project" />
     <orderEntry type="library" name="com.fasterxml.jackson.core:jackson-annotations:2.2.2@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="com.squareup:javawriter:2.1.1@jar" level="project" />
     <orderEntry type="library" name="com.google.code.gson:gson:2.8.1@jar" level="project" />
     <orderEntry type="library" name="android.arch.lifecycle:runtime-1.0.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-compat-27.0.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-basement-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-iid-11.6.0" level="project" />
     <orderEntry type="library" scope="TEST" name="com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
+    <orderEntry type="library" name="com.android.support:cardview-v7-27.0.1" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-database-connection-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-tasks-11.6.0" level="project" />
+    <orderEntry type="library" name="com.android.support:support-compat-27.0.1" level="project" />
     <orderEntry type="library" scope="TEST" name="org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:customtabs-26.1.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-messaging-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-location-license-11.6.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-media-compat-27.0.0" level="project" />
     <orderEntry type="library" scope="TEST" name="net.sf.kxml:kxml2:2.3.0@jar" level="project" />
+    <orderEntry type="library" name="com.android.support:support-media-compat-27.0.1" level="project" />
     <orderEntry type="library" name="com.squareup.picasso:picasso:2.5.2@jar" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-base-11.6.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-v4-27.0.0" level="project" />
     <orderEntry type="library" name="com.squareup.okio:okio:1.4.0@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:appcompat-v7-27.0.0" level="project" />
+    <orderEntry type="library" name="com.android.support:support-v4-27.0.1" level="project" />
+    <orderEntry type="library" name="com.android.support:appcompat-v7-27.0.1" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-places-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-tasks-license-11.6.0" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-common-4.29.0" level="project" />
     <orderEntry type="library" name="com.android.support:transition-27.0.0" level="project" />
     <orderEntry type="library" scope="TEST" name="com.android.support.test.espresso:espresso-core-3.0.1" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-share-4.28.0" level="project" />
     <orderEntry type="library" name="com.parse.bolts:bolts-applinks:1.4.0@jar" level="project" />
     <orderEntry type="library" name="com.firebase:firebase-client-jvm:2.5.2@jar" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-messenger-4.28.0" level="project" />
     <orderEntry type="library" name="com.firebaseui:firebase-ui-auth-3.1.0" level="project" />
     <orderEntry type="library" name="cz.msebera.android:httpclient:4.3.6@jar" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-database-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-database-connection-11.6.0" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-android-sdk-4.28.0" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-core-4.29.0" level="project" />
     <orderEntry type="library" name="com.parse.bolts:bolts-android:1.4.0@jar" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-auth-base-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-maps-11.6.0" level="project" />
     <orderEntry type="library" scope="TEST" name="org.hamcrest:hamcrest-library:1.3@jar" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-location-11.6.0" level="project" />
     <orderEntry type="library" name="com.loopj.android:android-async-http:1.4.9@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:support-annotations:27.0.0@jar" level="project" />
     <orderEntry type="library" name="com.squareup:android-times-square-1.5.0" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-login-4.28.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-database-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-auth-11.6.0" level="project" />
     <orderEntry type="library" name="android.arch.lifecycle:common:1.0.0@jar" level="project" />
     <orderEntry type="library" name="de.hdodenhof:circleimageview-2.2.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-base-license-11.6.0" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-common-4.28.0" level="project" />
     <orderEntry type="library" name="com.parse.bolts:bolts-tasks:1.4.0@jar" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-auth-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.fasterxml.jackson.core:jackson-core:2.2.2@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:support-vector-drawable-27.0.0" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-messenger-4.29.0" level="project" />
+    <orderEntry type="library" name="com.android.support:customtabs-27.0.1" level="project" />
     <orderEntry type="library" scope="TEST" name="com.android.support.test:runner-1.0.1" level="project" />
     <orderEntry type="library" name="com.fasterxml.jackson.core:jackson-databind:2.2.2@jar" level="project" />
+    <orderEntry type="library" name="com.android.support:support-vector-drawable-27.0.1" level="project" />
     <orderEntry type="library" scope="TEST" name="com.android.support.test.espresso:espresso-idling-resource-3.0.1" level="project" />
     <orderEntry type="library" scope="TEST" name="org.hamcrest:hamcrest-core:1.3@jar" level="project" />
     <orderEntry type="library" name="com.firebase:geofire-android-2.1.3" level="project" />
     <orderEntry type="library" name="com.firebase:tubesock:0.0.12@jar" level="project" />
     <orderEntry type="library" name="com.github.stfalcon:chatkit-0.2.2" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-android-sdk-4.29.0" level="project" />
     <orderEntry type="library" name="com.stripe:stripe-android-6.0.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-common-11.6.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-core-ui-27.0.0" level="project" />
     <orderEntry type="library" name="android.arch.core:common:1.0.0@jar" level="project" />
     <orderEntry type="library" name="com.android.support.constraint:constraint-layout-1.1.0-beta1" level="project" />
+    <orderEntry type="library" name="com.android.support:support-core-ui-27.0.1" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-core-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-common-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-places-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.zxing:core:3.3.0@jar" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-login-4.29.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-auth-11.6.0" level="project" />
-    <orderEntry type="library" name="com.android.support:support-fragment-27.0.0" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-core-4.28.0" level="project" />
+    <orderEntry type="library" name="com.android.support:support-fragment-27.0.1" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-analytics-impl-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-auth-api-phone-license-11.6.0" level="project" />
+    <orderEntry type="library" name="com.facebook.android:facebook-applinks-4.29.0" level="project" />
     <orderEntry type="library" name="com.android.support.constraint:constraint-layout-solver:1.1.0-beta1@jar" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-places-4.28.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-iid-license-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-auth-api-phone-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.android:flexbox-0.2.5" level="project" />
@@ -201,6 +194,7 @@
     <orderEntry type="library" scope="TEST" name="javax.inject:javax.inject:1@jar" level="project" />
     <orderEntry type="library" name="com.squareup.okhttp:okhttp:2.4.0@jar" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-maps-license-11.6.0" level="project" />
+    <orderEntry type="library" name="com.android.support:support-annotations:27.0.1@jar" level="project" />
     <orderEntry type="library" name="com.google.android.gms:play-services-basement-11.6.0" level="project" />
     <orderEntry type="library" name="com.android.support:recyclerview-v7-27.0.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-analytics-11.6.0" level="project" />
@@ -210,8 +204,7 @@
     <orderEntry type="library" name="com.firebase:firebase-jobdispatcher-0.6.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-messaging-11.6.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-analytics-impl-license-11.6.0" level="project" />
-    <orderEntry type="library" name="com.android.support:cardview-v7-26.1.0" level="project" />
-    <orderEntry type="library" name="com.facebook.android:facebook-applinks-4.28.0" level="project" />
     <orderEntry type="library" name="com.google.firebase:firebase-analytics-license-11.6.0" level="project" />
+    <orderEntry type="library" name="android-android-26" level="project" />
   </component>
 </module>


### PR DESCRIPTION
This allows for showing or hiding of fragments, and the recollection of existing fragments whenever app lifecycle methods such as onCreate() and onDestroy() are called. Should work correctly for orientation change, killing app process, and switching rapidly between menu tabs.

In addition, the back button is now overridden, such that if it is pressed when the selected tab is not on "home", the home page will be loaded. If already on the home page, the event is passed on to the superclass.